### PR TITLE
fix duplicated error feedback from CLI 

### DIFF
--- a/cmd/inst/flags.go
+++ b/cmd/inst/flags.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"log"
+	"os"
 
 	flags "github.com/jessevdk/go-flags"
 )
@@ -17,8 +17,17 @@ var opts struct {
 }
 
 func parseFlags() {
-	_, err := flags.Parse(&opts)
-	if err != nil {
-		log.Panic(err)
+
+	if _, err := flags.Parse(&opts); err != nil {
+		switch flagsErr := err.(type) {
+		case flags.ErrorType:
+			if flagsErr == flags.ErrHelp {
+				os.Exit(0)
+			}
+			os.Exit(1)
+		default:
+			os.Exit(1)
+		}
 	}
+
 }

--- a/cmd/inst/main.go
+++ b/cmd/inst/main.go
@@ -4,9 +4,11 @@ import (
 	"gfuzz/pkg/inst"
 	"gfuzz/pkg/inst/pass"
 	"log"
+	"os"
 )
 
 func main() {
+
 	parseFlags()
 
 	reg := inst.NewPassRegistry()
@@ -56,6 +58,11 @@ func main() {
 
 	if opts.Out != "" && len(goSrcFiles) != 1 {
 		log.Panic("--out is only allow with instrumenting single golang source file")
+	}
+
+	if len(goSrcFiles) == 0 {
+		log.Println("No go source file(s) found")
+		os.Exit(0)
 	}
 
 	// handle go source files


### PR DESCRIPTION
Example Output:

```bash
xsh@littlegray GFuzz % ./bin/inst -h 
Usage:
  inst [OPTIONS] [Globs...]

Application Options:
      --pass=  A list of passes you want to use in this instrumentation
      --dir=   Instrument all go source files under this directory
      --file=  Instrument single go source file
      --out=   Output instrumented golang source file to the given file. Only allow when instrumenting single golang source file

Help Options:
  -h, --help   Show this help message

xsh@littlegray GFuzz %
```

Fixed issue #2